### PR TITLE
Load and Save an ApiContext from and to JSON Data

### DIFF
--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -258,7 +258,7 @@ class ApiContext(object):
         """
         Serializes an ApiInstance to JSON data
 
-        :return: str
+        :rtype: str
         """
         return converter.class_to_json(self)
 
@@ -267,8 +267,9 @@ class ApiContext(object):
         """
         Creates an ApiContext instance from JSON data
 
-        :param data: str
-        :return: ApiContext
+        :type data: str
+
+        :rtype: ApiContext
         """
         return converter.json_to_class(ApiContext, data)
 

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -256,21 +256,23 @@ class ApiContext(object):
 
     def to_json(self):
         """
-        Serializes an ApiInstance to JSON data
+        Serializes an ApiContext to JSON string
 
         :rtype: str
         """
+
         return converter.class_to_json(self)
 
     @classmethod
     def from_json(cls, data):
         """
-        Creates an ApiContext instance from JSON data
+        Creates an ApiContext instance from JSON string.
 
         :type data: str
 
         :rtype: ApiContext
         """
+
         return converter.json_to_class(ApiContext, data)
 
     def save(self, path=None):

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -259,7 +259,7 @@ class ApiContext(object):
         :type path: str
         :type to_json: bool
 
-        :rtype: None
+        :rtype: Union[None, str]
         """
 
         if path is None:
@@ -288,6 +288,11 @@ class ApiContext(object):
 
         with open(path, cls._FILE_MODE_READ) as file:
             return converter.json_to_class(ApiContext, file.read())
+
+    def __eq__(self, other):
+        return self.token == other.token \
+               and self.api_key == other.api_key \
+               and self.environment_type == other.environment_type
 
 
 class InstallationContext(object):

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -254,27 +254,6 @@ class ApiContext(object):
 
         return self._session_context
 
-    def to_json(self):
-        """
-        Serializes an ApiContext to JSON string
-
-        :rtype: str
-        """
-
-        return converter.class_to_json(self)
-
-    @classmethod
-    def from_json(cls, data):
-        """
-        Creates an ApiContext instance from JSON string.
-
-        :type data: str
-
-        :rtype: ApiContext
-        """
-
-        return converter.json_to_class(ApiContext, data)
-
     def save(self, path=None):
         """
         :type path: str
@@ -287,6 +266,15 @@ class ApiContext(object):
 
         with open(path, self._FILE_MODE_WRITE) as file_:
             file_.write(self.to_json())
+
+    def to_json(self):
+        """
+        Serializes an ApiContext to JSON string.
+
+        :rtype: str
+        """
+
+        return converter.class_to_json(self)
 
     @classmethod
     def restore(cls, path=None):
@@ -301,6 +289,18 @@ class ApiContext(object):
 
         with open(path, cls._FILE_MODE_READ) as file_:
             return cls.from_json(file_.read())
+        
+    @classmethod
+    def from_json(cls, json_str):
+        """
+        Creates an ApiContext instance from JSON string.
+
+        :type json_str: str
+
+        :rtype: ApiContext
+        """
+
+        return converter.json_to_class(ApiContext, json_str)
 
     def __eq__(self, other):
         return (self.token == other.token and

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -277,7 +277,7 @@ class ApiContext(object):
         """
         :type path: str
 
-        :rtype: None, str
+        :rtype: None
         """
 
         if path is None:

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -254,9 +254,10 @@ class ApiContext(object):
 
         return self._session_context
 
-    def save(self, path=None):
+    def save(self, path=None, to_json=False):
         """
         :type path: str
+        :type to_json: bool
 
         :rtype: None
         """
@@ -264,19 +265,26 @@ class ApiContext(object):
         if path is None:
             path = self._PATH_API_CONTEXT_DEFAULT
 
+        if to_json:
+            return converter.class_to_json(self)
+
         with open(path, self._FILE_MODE_WRITE) as file:
             file.write(converter.class_to_json(self))
 
     @classmethod
-    def restore(cls, path=None):
+    def restore(cls, path=None, json_data=None):
         """
         :type path: str
+        :type json_data: str
 
         :rtype: ApiContext
         """
 
         if path is None:
             path = cls._PATH_API_CONTEXT_DEFAULT
+
+        if json_data is not None:
+            return converter.json_to_class(ApiContext, json_data)
 
         with open(path, cls._FILE_MODE_READ) as file:
             return converter.json_to_class(ApiContext, file.read())

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -254,28 +254,41 @@ class ApiContext(object):
 
         return self._session_context
 
-    def save(self, path=None, to_json=False):
+    def to_json(self):
+        """
+        Serializes an ApiInstance to JSON data
+
+        :return: str
+        """
+        return converter.class_to_json(self)
+
+    @classmethod
+    def from_json(cls, data):
+        """
+        Creates an ApiContext instance from JSON data
+
+        :param data: str
+        :return: ApiContext
+        """
+        return converter.json_to_class(ApiContext, data)
+
+    def save(self, path=None):
         """
         :type path: str
-        :type to_json: bool
 
-        :rtype: Union[None, str]
+        :rtype: None, str
         """
 
         if path is None:
             path = self._PATH_API_CONTEXT_DEFAULT
 
-        if to_json:
-            return converter.class_to_json(self)
-
-        with open(path, self._FILE_MODE_WRITE) as file:
-            file.write(converter.class_to_json(self))
+        with open(path, self._FILE_MODE_WRITE) as file_:
+            file_.write(self.to_json())
 
     @classmethod
-    def restore(cls, path=None, json_data=None):
+    def restore(cls, path=None):
         """
         :type path: str
-        :type json_data: str
 
         :rtype: ApiContext
         """
@@ -283,16 +296,13 @@ class ApiContext(object):
         if path is None:
             path = cls._PATH_API_CONTEXT_DEFAULT
 
-        if json_data is not None:
-            return converter.json_to_class(ApiContext, json_data)
-
-        with open(path, cls._FILE_MODE_READ) as file:
-            return converter.json_to_class(ApiContext, file.read())
+        with open(path, cls._FILE_MODE_READ) as file_:
+            return cls.from_json(file_.read())
 
     def __eq__(self, other):
-        return self.token == other.token \
-               and self.api_key == other.api_key \
-               and self.environment_type == other.environment_type
+        return (self.token == other.token and
+                self.api_key == other.api_key and
+                self.environment_type == other.environment_type)
 
 
 class InstallationContext(object):

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,16 @@ of a configuration file is located at [`tests/assets/config.example.json`](./ass
 In order to make use of the configuration file, please copy the example to the
 same directory, fill in your sandbox user data and rename the copy to config.json.
 
+Note:
+* `MONETARY_ACCOUNT_ID` and `MONETARY_ACCOUNT_ID2` must be of same user
+* `CounterPartyOther` must be of another Sandbox user
+* You can create a `CASH_REGISTER_ID` on doc.bunq.com
+    1. Add your **Developer Key** to `settings`
+    2. Upload an image to the `Attachment Public` endpoint
+    3. Create an `Avatar` with the returned UUID
+    4. Use the Avatar's UUID to create a `Cash Register`
+    5. Copy the Cash Register's ID to the `config.json`
+
 ## Execution
 
 You can run the tests via command line: 

--- a/tests/model/generated/test_api_context.py
+++ b/tests/model/generated/test_api_context.py
@@ -1,0 +1,85 @@
+import os
+
+from bunq.sdk.context import ApiContext
+from bunq.sdk.json import converter
+from tests.bunq_test import BunqSdkTestCase
+
+
+class ApiContextTest(BunqSdkTestCase):
+    """
+    Tests:
+        ApiContext
+    """
+
+    _TMP_FILE_PATH = '/context-save-test.conf'
+
+    @classmethod
+    def setUpClass(cls):
+        cls._FILE_MODE_READ = ApiContext._FILE_MODE_READ
+        cls._API_CONTEXT = cls._get_api_context()
+        cls._TMP_FILE_PATH_FULL = (cls._get_directory_test_root() +
+                                   cls._TMP_FILE_PATH)
+
+    def test_api_context_save(self):
+        """
+        Converts an ApiContext to JSON data, saves the same ApiContext to a
+        temporary file, and compares whether the JSON data is equal to the
+        data in the file.
+
+        Removes the temporary file before assertion.
+        """
+
+        context_json = converter.class_to_json(self._API_CONTEXT)
+
+        self._API_CONTEXT.save(self._TMP_FILE_PATH_FULL)
+
+        with open(self._TMP_FILE_PATH_FULL, self._FILE_MODE_READ) as file:
+            context_retrieved = file.read()
+
+        os.remove(self._TMP_FILE_PATH_FULL)
+
+        self.assertEqual(context_retrieved, context_json)
+
+    def test_api_context_restore(self):
+        """
+        Saves an ApiContext to a temporary file, restores an ApiContext from
+        that file, and compares whether the api_keys, tokens, and environment
+        types are equal in the ApiContext and the restored ApiContext.
+
+        Removes the temporary file before assertion.
+        """
+
+        self._API_CONTEXT.save(self._TMP_FILE_PATH_FULL)
+        api_context_restored = ApiContext.restore(self._TMP_FILE_PATH_FULL)
+
+        os.remove(self._TMP_FILE_PATH_FULL)
+
+        self.assertEqual(api_context_restored, self._API_CONTEXT)
+
+    def test_api_context_save_json(self):
+        """
+        Converts an ApiContext to JSON data, saves the ApiContext using the
+        ApiContext.save() function with the to_JSON flag set to True, and
+        compares whether the JSON data equals the returned JSON data from the
+        ApiContext.save() function.
+        """
+
+        context_json = converter.class_to_json(self._API_CONTEXT)
+        context_saved = self._API_CONTEXT.save(to_json=True)
+
+        self.assertEqual(context_saved, context_json)
+
+    def test_api_context_restore_json(self):
+        """
+        Saves an ApiContext with the ApiContext.save() function with the
+        to_JSON flag set to True, restores an ApiContext from the JSON data
+        returned from the ApiContext.save() function, and checks that the
+        api_key, token, and environment type variables of the restored
+        ApiContext are equal to the respective variables in the original
+        ApiContext.
+        """
+
+        context_json = self._API_CONTEXT.save(to_json=True)
+        api_context_restored = self._API_CONTEXT.restore(json_data=context_json)
+
+        self.assertEqual(api_context_restored, self._API_CONTEXT)

--- a/tests/model/generated/test_api_context.py
+++ b/tests/model/generated/test_api_context.py
@@ -33,8 +33,8 @@ class ApiContextTest(BunqSdkTestCase):
 
         self._API_CONTEXT.save(self._TMP_FILE_PATH_FULL)
 
-        with open(self._TMP_FILE_PATH_FULL, self._FILE_MODE_READ) as file:
-            context_retrieved = file.read()
+        with open(self._TMP_FILE_PATH_FULL, self._FILE_MODE_READ) as file_:
+            context_retrieved = file_.read()
 
         os.remove(self._TMP_FILE_PATH_FULL)
 
@@ -65,7 +65,7 @@ class ApiContextTest(BunqSdkTestCase):
         """
 
         context_json = converter.class_to_json(self._API_CONTEXT)
-        context_saved = self._API_CONTEXT.save(to_json=True)
+        context_saved = self._API_CONTEXT.to_json()
 
         self.assertEqual(context_saved, context_json)
 
@@ -79,7 +79,7 @@ class ApiContextTest(BunqSdkTestCase):
         ApiContext.
         """
 
-        context_json = self._API_CONTEXT.save(to_json=True)
-        api_context_restored = self._API_CONTEXT.restore(json_data=context_json)
+        context_json = self._API_CONTEXT.to_json()
+        api_context_restored = self._API_CONTEXT.from_json(context_json)
 
         self.assertEqual(api_context_restored, self._API_CONTEXT)


### PR DESCRIPTION
I added a small functionality to save and load an ApiContext to and from JSON Data.
Previously, the ApiContext was always saved to and loaded from a file, but this restricted me from saving the config of an ApiContext in a database. I also added unittests for the original ApiContext.save() and ApiContext.restore() functions and their modified versions. 

I also added clarification for some of the variables that one need to set in the `conf.json` in `tests/example/`. 