### PR TITLE
Added isSessionExpired() method #31.

### DIFF
--- a/bunq/sdk/client.py
+++ b/bunq/sdk/client.py
@@ -105,6 +105,7 @@ class ApiClient(object):
                                                               params)
         if uri_relative not in self._URIS_NOT_REQUIRING_ACTIVE_SESSION:
             self._api_context.ensure_session_active()
+
         all_headers = self._get_all_headers(
             method,
             uri_relative_with_params,

--- a/bunq/sdk/client.py
+++ b/bunq/sdk/client.py
@@ -15,6 +15,16 @@ class ApiClient(object):
     :type _api_context: bunq.sdk.context.ApiContext
     """
 
+    # Endpoints not requiring active session for the request to succeed.
+    _URL_DEVICE_SERVER = 'device-server'
+    _URI_INSTALLATION = 'installation'
+    _URI_SESSION_SERVER = 'session-server'
+    _URIS_NOT_REQUIRING_ACTIVE_SESSION = [
+        _URI_INSTALLATION,
+        _URI_SESSION_SERVER,
+        _URL_DEVICE_SERVER,
+    ]
+
     # HTTPS type of proxy, the only used at bunq
     _FIELD_PROXY_HTTPS = 'https'
 
@@ -93,7 +103,8 @@ class ApiClient(object):
 
         uri_relative_with_params = self._append_params_to_uri(uri_relative,
                                                               params)
-        self._api_context.ensure_session_active()
+        if uri_relative not in self._URIS_NOT_REQUIRING_ACTIVE_SESSION:
+            self._api_context.ensure_session_active()
         all_headers = self._get_all_headers(
             method,
             uri_relative_with_params,

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -175,7 +175,6 @@ class ApiContext(object):
 
     def is_session_active(self):
         """
-        :return: True if it has expired, otherwise false
         :rtype: bool
         """
 

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -166,10 +166,14 @@ class ApiContext(object):
             return session_server.user_person.session_timeout
 
     def ensure_session_active(self):
-        if self.is_session_expired() and self.session_context is not None:
+        """
+        Resets the session if it has expired.
+        """
+
+        if not self.is_session_active():
             self.reset_session()
 
-    def is_session_expired(self):
+    def is_session_active(self):
         """
         :return: True if it has expired, otherwise false
         :rtype: bool
@@ -184,7 +188,7 @@ class ApiContext(object):
             seconds=self._TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS
         )
 
-        return time_to_expiry < time_to_expiry_minimum
+        return time_to_expiry > time_to_expiry_minimum
 
     def reset_session(self):
         """

--- a/bunq/sdk/context.py
+++ b/bunq/sdk/context.py
@@ -166,8 +166,17 @@ class ApiContext(object):
             return session_server.user_person.session_timeout
 
     def ensure_session_active(self):
+        if self.is_session_expired() and self.session_context is not None:
+            self.reset_session()
+
+    def is_session_expired(self):
+        """
+        :return: True if it has expired, otherwise false
+        :rtype: bool
+        """
+
         if self.session_context is None:
-            return
+            return False
 
         time_now = datetime.datetime.now()
         time_to_expiry = self.session_context.expiry_time - time_now
@@ -175,8 +184,7 @@ class ApiContext(object):
             seconds=self._TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS
         )
 
-        if time_to_expiry < time_to_expiry_minimum:
-            self.reset_session()
+        return time_to_expiry < time_to_expiry_minimum
 
     def reset_session(self):
         """


### PR DESCRIPTION
## Context 
#31 

## What has been done
This pr introduces a new way to handle `SessionContext`. Now it is possible to do the following:

```
if api_context.is_session_expired():
    api_context.reset_session()
    api_context.save()
```

This way there is no saving an unchanged context.

Closes #31 