### PR TITLE
Markdown fix. (bunq/sdk_python#113)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
 
     description='bunq Python SDK',
     long_description=long_description,
+    long_description_content_type="text/markdown",
 
     # The project's main homepage.
     url='https://github.com/bunq/sdk_python',


### PR DESCRIPTION
Fixes being unable to upload a new version of SDK to PyPI.

 - Closes bunq/sdk_python#113
 - Tested to fix the problem provided setup tools, twine and friends are at the last version.