### PR TITLE
Update bunq_model.py (bunq/sdk_python#145)

### DIFF
--- a/bunq/sdk/model/core/bunq_model.py
+++ b/bunq/sdk/model/core/bunq_model.py
@@ -101,6 +101,16 @@ class BunqModel:
 
         for item in array:
             item_unwrapped = item if wrapper is None else item[wrapper]
+            # item_unwrapped needs to be deserialized to NotificationFilterUrl (wrapper) 
+            #   when cls is NotificationFilterUrlUser or NotificationFilterUrlMonetaryAccount
+            if wrapper=='NotificationFilterUrl':
+                from bunq.sdk.model.generated.endpoint import NotificationFilterUrlUser, NotificationFilterUrlMonetaryAccount
+                from bunq.sdk.model.generated.object_ import NotificationFilterUrl
+                if cls == NotificationFilterUrlUser or cls == NotificationFilterUrlMonetaryAccount:
+                    cls_orig = cls
+                    cls = NotificationFilterUrl
+                    #print(f'NotificationFilterUrlUser deserialization, changing cls from: {cls_orig} to: {cls}')
+                    #TODO: Test deserialize for NotificationFilterUrlUser and NotificationFilterUrlMonetaryAccount
             item_deserialized = converter.deserialize(cls, item_unwrapped)
             array_deserialized.append(item_deserialized)
 


### PR DESCRIPTION
@classmethod BunqModel._from_json_list assumes that the endpoint name is the same as the model name. This does not work for the abstract type NotificationFilterUrl which can be loaded from multiple endpoints (NotificationFilterUrlUser, NotificationFilterUrlMonetaryAccount)

item_unwrapped in "BunqModel._from_json_list" needs to be deserialized to NotificationFilterUrl (wrapper) when cls is NotificationFilterUrlUser or NotificationFilterUrlMonetaryAccount

[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_python#<issue nr>\)".
         If this pull request is changing files that are located in "bunq/sdk/model/generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues:
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Closes bunq/sdk_python#
    - [ ] Tested
