### PR TITLE
BunqModel updates for NotificationFilterUrl

### DIFF
--- a/bunq/sdk/model/core/bunq_model.py
+++ b/bunq/sdk/model/core/bunq_model.py
@@ -58,7 +58,11 @@ class BunqModel:
                                 obj: Dict,
                                 wrapper: str = None) -> Dict:
         if wrapper is not None:
-            return obj[cls._FIELD_RESPONSE][cls._INDEX_FIRST][wrapper]
+            from bunq.sdk.model.generated.endpoint import NotificationFilterUrlUser, NotificationFilterUrlMonetaryAccount
+            if cls == NotificationFilterUrlUser or cls == NotificationFilterUrlMonetaryAccount:
+                return obj[cls._FIELD_RESPONSE][cls._INDEX_FIRST]['NotificationFilterUrl']
+            else:
+                return obj[cls._FIELD_RESPONSE][cls._INDEX_FIRST][wrapper]
 
         return obj[cls._FIELD_RESPONSE][cls._INDEX_FIRST]
 


### PR DESCRIPTION
This PR closes/fixes the following issues: NotificationFilterUrl creation / listing on NotificationFilterUrlUser and NotificationFilterUrlMonetaryAccount.

The endpoint and model differ for NotificationFilterUrl since there are two endpoints for this model. NotificationFilterUrlUser and NotificationFilterUrlMonetaryAccount. 

(These changes does import subclasses into the superclass to do condition checks)

 - Closes bunq/sdk_python#145
    - [ ] Tested
